### PR TITLE
update to java junit with jdk 18

### DIFF
--- a/git_repo_urls.tagged
+++ b/git_repo_urls.tagged
@@ -45,7 +45,7 @@ ec0081d@https://github.com/cyber-dojo-start-points/java-approval
 8d6fe4f@https://github.com/cyber-dojo-start-points/java-cucumberpico
 dc85ca6@https://github.com/cyber-dojo-start-points/java-cucumberspring
 f421d70@https://github.com/cyber-dojo-start-points/java-jmock
-3240009@https://github.com/cyber-dojo-start-points/java-junit
+c23ed9e@https://github.com/cyber-dojo-start-points/java-junit
 8ace506@https://github.com/cyber-dojo-start-points/java-mockito
 ad18b1f@https://github.com/cyber-dojo-start-points/java-powermockito
 1a47268@https://github.com/cyber-dojo-start-points/java-sqlite


### PR DESCRIPTION
I am a bit confused why the previous version I replace isn't the same as here https://github.com/cyber-dojo-start-points/java-junit/pull/5/files  so I hope it's correct. Maybe have a 2nd look at it.