### PR TITLE
Remove snyk-container-scan from CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,60 +167,11 @@ jobs:
           key:  ${{ env.CACHE_KEY }}
 
 
-  snyk-container-scan:
-    needs: [build-image]
-    runs-on: ubuntu-latest
-    env:
-      IMAGE_NAME:        ${{ needs.build-image.outputs.tagged_image_name }}
-      KOSLI_FINGERPRINT: ${{ needs.build-image.outputs.digest }}
-      CACHE_KEY:         ${{ needs.build-image.outputs.cache_key }}
-      CACHE_PATH:        ${{ needs.build-image.outputs.cache_path }}
-      SARIF_FILENAME:    snyk.container.scan.json
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Retrieve Docker image from cache
-        uses: actions/cache@v4
-        with:
-          key:  ${{ env.CACHE_KEY }}
-          path: ${{ env.CACHE_PATH }}
-
-      - name: Load Docker image
-        run:
-          docker image load --input "${{ env.CACHE_PATH }}"
-
-      - name: Setup Snyk
-        uses: snyk/actions/setup@master
-
-      - name: Run Snyk container scan
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run:
-          snyk container test ${IMAGE_NAME} 
-            --policy-path=.snyk
-            --sarif 
-            --sarif-file-output="${SARIF_FILENAME}" 
-
-      - name: Setup Kosli CLI
-        if: ${{ github.ref == 'refs/heads/main' && (success() || failure()) }}
-        uses: kosli-dev/setup-cli-action@v2
-        with:
-          version: ${{ vars.KOSLI_CLI_VERSION }}
-
-      - name: Attest evidence to Kosli
-        if: ${{ github.ref == 'refs/heads/main' && (success() || failure()) }}
-        run:
-          kosli attest snyk 
-            --attachments=.snyk          
-            --name=languages-start-points.snyk-container-scan 
-            --scan-results="${SARIF_FILENAME}"
-
-
   sdlc-control-gate:
     if: ${{ github.ref == 'refs/heads/main' }}
-    needs: [pull-request, build-image, snyk-container-scan]
+    needs:
+      - pull-request
+      - build-image
     runs-on: ubuntu-latest
     env:
       KOSLI_FINGERPRINT: ${{ needs.build-image.outputs.digest }}

--- a/.kosli.yml
+++ b/.kosli.yml
@@ -4,8 +4,3 @@ trail:
   attestations:
     - name: pull-request
       type: pull_request
-  artifacts:
-    - name: languages-start-points
-      attestations:
-        - name: snyk-container-scan
-          type: snyk


### PR DESCRIPTION
Currently, the snyk-container-scan produces no terminal output, does not create the requested sarif file, and exits with a status code of zero. How rubbish is that! So I am taking the opportunity to move to a new snyk process design inspired by Tore's work. The snyk-scans will now happen only in a dedicated process with its own cron workflow. And I will work towards implementing a policy of making a failed snyk attestation only become non-compliant if it is not fixed in 7 days.